### PR TITLE
fix: readme travis redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# react-experimentify [![Build Status](https://travis-ci.org/DomainGroupOSS/react-experimentify.svg?branch=master)](https://travis-ci.org/DomainGroupOSS/react-experimentify.svg?branch=master) ![npm-version]
+# react-experimentify [![Build Status](https://travis-ci.org/DomainGroupOSS/react-experimentify.svg?branch=master)](https://travis-ci.com/DomainGroupOSS/react-experimentify) ![npm-version]
 
 ### Features
 


### PR DESCRIPTION
### This is a

- [ ] Breaking change
- [ ] New feature
- [x] Bugfix

### I have

- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ ] Made sure the dependencies in [`package.json`](package.json) are up to date

### What's changed

bugfix - redirect to Travis on build status image click
