### PR TITLE
Replace componentWillMount() with componentDidMount()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][]
+- Replace deprecated `componentWillMount()` with `componentDidMount()`
 
 ## [1.0.8][] - 2019-04-08
 ### Fixed

--- a/src/control.js
+++ b/src/control.js
@@ -4,7 +4,7 @@ import warning from 'warning';
 import Context from './experiment-context';
 
 class Control extends React.Component {
-  componentWillMount() {
+  componentDidMount() {
     const { render, children } = this.props;
 
     warning(

--- a/src/experiment.js
+++ b/src/experiment.js
@@ -5,7 +5,7 @@ import ExperimentModel from './models/experiment';
 import Context from './experiment-context';
 
 class Experiment extends React.Component {
-  componentWillMount() {
+  componentDidMount() {
     const { children } = this.props;
 
     invariant(

--- a/src/treatment.js
+++ b/src/treatment.js
@@ -4,7 +4,7 @@ import warning from 'warning';
 import Context from './experiment-context';
 
 class Treatment extends React.Component {
-  componentWillMount() {
+  componentDidMount() {
     const { render, children } = this.props;
 
     warning(


### PR DESCRIPTION
### This is a

- [ ] Breaking change
- [ ] New feature
- [x] Bugfix

### I have

- [x] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ ] Made sure the dependencies in [`package.json`](package.json) are up to date

### What's changed

I've replaced the deprecated lifecycle method `componentWillMount()` `with componentDidMount()`.